### PR TITLE
Added vagrant-libvirt-doc rpm and polkit rule

### DIFF
--- a/ipa.sh
+++ b/ipa.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-sudo dnf install -y freeipa-server freeipa-server-dns sssd-dbus mod_lookup_identity mod_authnz_pam haveged nmap-ncat nano pamtester
+sudo dnf install -y freeipa-server freeipa-server-dns sssd-dbus mod_lookup_identity mod_authnz_pam haveged nmap-ncat nano pamtester bash-completion
 sudo systemctl enable haveged
 sudo sh -c "echo 'PS1=\"[\u@\h]\\\\$ \"' >> /etc/profile"
 sudo sh -c "echo 'PS1=\"[\h]\\\\$ \"' >> /etc/bashrc"

--- a/workshop.rst
+++ b/workshop.rst
@@ -96,10 +96,24 @@ Fedora
 ^^^^^^
 
 If you intend to use the ``libvirt`` provider (recommended), install
-``vagrant-libvirt``::
+``vagrant-libvirt`` and ``vagrant-libvirt-doc``::
 
-  $ sudo dnf install -y vagrant-libvirt
+  $ sudo dnf install -y vagrant-libvirt vagrant-libvirt-doc
 
+Allow your regular user ID to start and stop Vagrant boxes. A PolicyKit rule
+will be added that allows users in the vagrant group to control VMs through
+libvirt. The necessary rule is included in the ``vagrant-libvirt-doc`` 
+package. Run the following commands to add your local user to the vagrant 
+group and to copy the necessary rule to the right place::
+
+  $ usermod -a -G vagrant $USER
+  $ cp /usr/share/vagrant/gems/doc/vagrant-libvirt-*/polkit/10-vagrant-libvirt.rules \
+    /etc/polkit-1/rules.d
+
+Finally restart the services::
+
+  $ systemctl restart libvirtd
+  $ systemctl restart polkit
 
 Otherwise, you will use VirtualBox and the ``virtualbox`` provider.
 VirtualBox needs to build kernel modules, and that means that you must

--- a/workshop.rst
+++ b/workshop.rst
@@ -275,15 +275,17 @@ From the directory containing the ``Vagrantfile``, SSH into the
 
 On ``server``, start the FreeIPA server installation program::
 
-  [server]$ sudo ipa-server-install --no-host-dns
+  [server]$ sudo ipa-server-install --no-host-dns --mkhomedir
 
 The ``--no-host-dns`` argument is needed because there is no DNS PTR
 resolution for the Vagrant environment.  For production deployment,
-this important sanity check should not be skipped.
+this important sanity check should not be skipped. The ``--mkhomedir`` 
+flag configure PAM to create missing home directories when users log 
+into the host for the first time. FreeIPA supports automount so 
+consider using that for production deployments.
 
-You will be asked a series of questions.
-Accept the defaults for most of the questions, except as outlined
-below.
+You will be asked a series of questions. Accept the defaults for most 
+of the questions, except as outlined below.
 
 Configure FreeIPA's DNS server::
 
@@ -403,11 +405,6 @@ From the directory that contains the ``Vagrantfile``, SSH into the
 On ``client``, start the FreeIPA client enrolment program::
 
   [client]$ sudo ipa-client-install --mkhomedir
-
-The ``--mkhomedir`` flag configure PAM to create missing home
-directories when users log into the host for the first time.
-FreeIPA supports automount so consider using that for production
-deployments.
 
 The FreeIPA server should be detected through DNS autodiscovery.
 (If DNS discovery fails, e.g. due to client machine having incorrect
@@ -1182,7 +1179,7 @@ details.
 SSH to the ``replica`` VM and install the replica::
 
   % vagrant ssh replica
-  [replica]$ sudo ipa-replica-install replica.gpg 
+  [replica]$ sudo ipa-replica-install --mkhomedir replica.gpg 
   Directory Manager (existing master) password: 
 
   Run connection check to master


### PR DESCRIPTION
Allow regular users to manage vagrant boxes when using the libvirt framework.
