### PR TITLE
Workaround networking issues with Libvirt

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,7 @@ Vagrant.configure(2) do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.provider :libvirt do |libvirt|
+    libvirt.qemu_use_session = false
     libvirt.memory = 1024
   end
 


### PR DESCRIPTION
Vagrant 2.2 on Fedora 30 enables QEMU Session by default [1] which causes
problems with setting up the private network.

Explicitly telling Vagrant not to use the QEMU session if we're running on
Libvirt is the suggested workaround for now.

[1] https://fedoraproject.org/wiki/Changes/Vagrant_2.2_with_QEMU_Session