### PR TITLE
Forcing not to use QEMU

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provider :libvirt do |libvirt|
     libvirt.memory = 1024
+    libvirt.qemu_use_session = false
   end
 
   # Vagrant's "change host name" sets the short host name.  Before


### PR DESCRIPTION
Since Fedora 30 `libvirt.qemu_use_session` is enabled by default. This was causing problems with the current state of our Vagrantfile. Forcing this config to false fixes the problem.

See: https://fedoraproject.org/wiki/Changes/Vagrant_2.2_with_QEMU_Session